### PR TITLE
FEATURE: don't fail in checkmode if ansible hasn't been run before

### DIFF
--- a/tasks/install.yaml
+++ b/tasks/install.yaml
@@ -53,4 +53,4 @@
     dest: "{{ oauth2_proxy.prefix.opt }}/bin/oauth2_proxy"
     mode: "0755"
     owner: "root"
-  ignore_errors: "{{ ansible_check_mode }}"
+  failed_when: oauth2_proxy_install_binary_result.failed and not ansible_check_mode

--- a/tasks/install.yaml
+++ b/tasks/install.yaml
@@ -53,3 +53,4 @@
     dest: "{{ oauth2_proxy.prefix.opt }}/bin/oauth2_proxy"
     mode: "0755"
     owner: "root"
+  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
because the target-folder must not exist on first run, copy-task will fail